### PR TITLE
Add Work model support and generic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# marx-search
+# Marx Search
+
+This project provides a simple FastAPI backend and a React front end for
+searching various Marxist texts. The backend now supports multiple works
+via a `works` table and all resources can be filtered by `work_id`.
+
+Run `migrate.py` to initialize the database or add the `work_id` column to an
+existing one. By default the application uses a local SQLite database at
+`marx_texts.db`.

--- a/marx_search/database.py
+++ b/marx_search/database.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./capital_glossary.db"
+SQLALCHEMY_DATABASE_URL = "sqlite:///./marx_texts.db"
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/marx_search/main.py
+++ b/marx_search/main.py
@@ -24,6 +24,19 @@ def get_db():
     finally:
         db.close()
 
+
+@app.get("/works/", response_model=list[schemas.WorkOut])
+def list_works(db: Session = Depends(get_db)):
+    return db.query(models.Work).all()
+
+
+@app.get("/works/{work_id}", response_model=schemas.WorkOut)
+def get_work(work_id: int, db: Session = Depends(get_db)):
+    work = db.query(models.Work).filter(models.Work.id == work_id).first()
+    if not work:
+        raise HTTPException(status_code=404, detail="Work not found")
+    return work
+
 @app.get("/passages/{passage_id}", response_model=schemas.PassageOut)
 def get_passage(passage_id: str, db: Session = Depends(get_db)):
     passage = db.query(models.Passage).filter(models.Passage.id == passage_id).first()
@@ -35,6 +48,7 @@ def get_passage(passage_id: str, db: Session = Depends(get_db)):
 def list_passages(
     chapter: int = Query(None),
     section: int = Query(None),
+    work_id: int = Query(None),
     offset: int = 0,
     limit: int = 50,
     db: Session = Depends(get_db)
@@ -44,11 +58,16 @@ def list_passages(
         query = query.filter(models.Passage.chapter == chapter)
     if section is not None:
         query = query.filter(models.Passage.section == section)
+    if work_id is not None:
+        query = query.filter(models.Passage.work_id == work_id)
     return query.offset(offset).limit(limit).all()
 
 @app.get("/terms/", response_model=list[schemas.TermOut])
-def list_terms(db: Session = Depends(get_db)):
-    return db.query(models.Term).all()
+def list_terms(work_id: int = Query(None), db: Session = Depends(get_db)):
+    query = db.query(models.Term)
+    if work_id is not None:
+        query = query.filter(models.Term.work_id == work_id)
+    return query.all()
 
 @app.get("/terms/{term_id}", response_model=schemas.TermOut)
 def get_term(term_id: str, db: Session = Depends(get_db)):
@@ -64,16 +83,18 @@ from sqlalchemy.orm import aliased
 @app.get("/terms/{term_id}/passages", response_model=list[schemas.TermPassageLinkOut])
 def get_term_links(
     term_id: str,
+    work_id: int = Query(None),
     db: Session = Depends(get_db),
     page: int = 1,
     page_size: int = 10
 ):
     offset = (page - 1) * page_size
 
-    rows = (
+    query = (
         db.query(
             models.Passage.id.label("id"),
             models.TermPassageLink.passage_id,
+            models.TermPassageLink.work_id,
             models.Passage.chapter,
             models.Passage.section,
             models.Passage.paragraph,
@@ -85,10 +106,10 @@ def get_term_links(
         .join(models.Chapter, models.Chapter.id == models.Passage.chapter)
         .outerjoin(models.Section, (models.Section.chapter == models.Passage.chapter) & (models.Section.section == models.Passage.section))
         .filter(models.TermPassageLink.term_id == term_id)
-        .offset(offset)
-        .limit(page_size)
-        .all()
     )
+    if work_id is not None:
+        query = query.filter(models.TermPassageLink.work_id == work_id)
+    rows = query.offset(offset).limit(page_size).all()
 
     # Truncate and rename to match response schema
     results = []
@@ -102,7 +123,8 @@ def get_term_links(
             "paragraph": row.paragraph,
             "text_snippet": extract_context_snippet(row.text, term_id),
             "chapter_title": row.chapter_title,
-            "section_title": row.section_title
+            "section_title": row.section_title,
+            "work_id": row.work_id
         })
 
     return results
@@ -145,14 +167,20 @@ def extract_context_snippet(text, term, context_words=50):
 
 
 @app.get("/terms/{term_id}/passage_count")
-def count_term_links(term_id: str, db: Session = Depends(get_db)):
-    count = db.query(models.TermPassageLink).filter(models.TermPassageLink.term_id == term_id).count()
+def count_term_links(term_id: str, work_id: int = Query(None), db: Session = Depends(get_db)):
+    query = db.query(models.TermPassageLink).filter(models.TermPassageLink.term_id == term_id)
+    if work_id is not None:
+        query = query.filter(models.TermPassageLink.work_id == work_id)
+    count = query.count()
     return {"count": count}
 
 
 @app.get("/chapters/", response_model=list[schemas.ChapterOut])
-def get_chapters(db: Session = Depends(get_db)):
-    return db.query(models.Chapter).order_by(models.Chapter.id).all()
+def get_chapters(work_id: int = Query(None), db: Session = Depends(get_db)):
+    query = db.query(models.Chapter)
+    if work_id is not None:
+        query = query.filter(models.Chapter.work_id == work_id)
+    return query.order_by(models.Chapter.id).all()
 
 
 @app.get("/chapters/{chapter_id}", response_model=schemas.ChapterOut)
@@ -207,10 +235,12 @@ def get_chapter_data(chapter_id: int, db: Session = Depends(get_db)):
 
 
 @app.get("/sections/", response_model=list[schemas.SectionOut])
-def get_all_sections(chapter: int, db: Session = Depends(get_db)):
+def get_all_sections(chapter: int, work_id: int = Query(None), db: Session = Depends(get_db)):
     query = db.query(models.Section)
     if chapter is not None:
         query = query.filter(models.Section.chapter == chapter)
+    if work_id is not None:
+        query = query.filter(models.Section.work_id == work_id)
     return query.order_by(models.Section.id).all()
 
 
@@ -233,6 +263,7 @@ def search(
     exact: bool = Query(False),
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=100),
+    work_id: int = Query(None),
     db: Session = Depends(get_db),
 ):
     q_lower = q.lower()
@@ -241,7 +272,10 @@ def search(
     # -------------------------
     # Match Terms
     # -------------------------
-    all_terms = db.query(models.Term).all()
+    term_query = db.query(models.Term)
+    if work_id is not None:
+        term_query = term_query.filter(models.Term.work_id == work_id)
+    all_terms = term_query.all()
 
     if exact:
         matching_terms = [
@@ -257,7 +291,10 @@ def search(
     # -------------------------
     # Match Passages
     # -------------------------
-    all_passages = db.query(models.Passage).all()
+    passage_query = db.query(models.Passage)
+    if work_id is not None:
+        passage_query = passage_query.filter(models.Passage.work_id == work_id)
+    all_passages = passage_query.all()
 
     if exact:
         matched_passages = [
@@ -287,6 +324,7 @@ def search(
             "translation": p.translation,
             "chapter_title": chapter.title if chapter else None,
             "section_title": section.title if section else None,
+            "work_id": p.work_id,
         })
 
     return {

--- a/marx_search/migrate.py
+++ b/marx_search/migrate.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine, Column, Integer, String, Text, ForeignKey,
 from sqlalchemy.orm import sessionmaker, declarative_base
 
 # Setup
-engine = create_engine("sqlite:///capital_glossary.db")
+engine = create_engine("sqlite:///marx_texts.db")
 Session = sessionmaker(bind=engine)
 session = Session()
 Base = declarative_base()
@@ -37,13 +37,13 @@ Work.__table__.create(bind=engine, checkfirst=True)
 print("✅ Ensured 'works' table exists")
 
 # Insert default work
-capital = Work(title="Capital, Volume I", author="Karl Marx", description="The first volume of Capital.")
-session.add(capital)
+default_work = Work(title="Capital, Volume I", author="Karl Marx", description="The first volume of Capital.")
+session.add(default_work)
 session.commit()
-print(f"✅ Inserted work: {capital.title} with ID {capital.id}")
+print(f"✅ Inserted work: {default_work.title} with ID {default_work.id}")
 
 # Update all tables with work_id
-session.execute(text(f"UPDATE chapters SET work_id = {capital.id}"))
+session.execute(text(f"UPDATE chapters SET work_id = {default_work.id}"))
 session.execute(text(f"""
     UPDATE passages
     SET work_id = (
@@ -56,7 +56,7 @@ session.execute(text(f"""
         SELECT work_id FROM chapters WHERE chapters.id = sections.chapter
     )
 """))
-session.execute(text(f"UPDATE terms SET work_id = {capital.id}"))
+session.execute(text(f"UPDATE terms SET work_id = {default_work.id}"))
 session.execute(text(f"""
     UPDATE term_passage_link
     SET work_id = (

--- a/marx_search/models.py
+++ b/marx_search/models.py
@@ -48,6 +48,8 @@ class Section(Base):
     chapter = Column(Integer, nullable=False)
     section = Column(Integer, nullable=False)
     title = Column(String, nullable=False)
+    work_id = Column(Integer, ForeignKey("works.id"), nullable=False)
+    work = relationship("Work", backref="sections")
 
 
 class Part(Base):

--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -9,6 +9,7 @@ class PassageOut(BaseModel):
     paragraph: int
     text: str
     translation: str
+    work_id: int
 
     class Config:
         from_attributes = True
@@ -19,6 +20,7 @@ class TermOut(BaseModel):
     definition: str
     tags: str
     aliases: Optional[str]
+    work_id: int
 
     class Config:
         from_attributes = True
@@ -32,6 +34,7 @@ class TermPassageLinkOut(BaseModel):
     text_snippet: str
     chapter_title: str
     section_title: Optional[str]
+    work_id: int
 
     class Config:
         from_attributes = True
@@ -40,6 +43,7 @@ class TermPassageLinkOut(BaseModel):
 class ChapterOut(BaseModel):
     id: int
     title: str
+    work_id: int
 
     class Config:
         from_attributes = True
@@ -50,6 +54,7 @@ class SectionOut(BaseModel):
     chapter: int
     section: int
     title: str
+    work_id: int
 
     class Config:
         from_attributes = True
@@ -78,6 +83,17 @@ class PartOut(BaseModel):
     number: int
     title: str
     start_chapter: int
+
+    class Config:
+        from_attributes = True
+
+
+class WorkOut(BaseModel):
+    id: int
+    title: str
+    author: Optional[str] = None
+    year: Optional[str] = None
+    description: Optional[str] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- switch to a generic `marx_texts.db` database
- add `work_id` columns and relationships in models
- expose `/works` endpoints
- allow filtering by `work_id` in many endpoints and search
- include `work_id` in API schemas and responses
- update migration script and README
- add trailing newlines to various python files

## Testing
- `python -m py_compile marx_search/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68474d096950832ca2d309148fe47b1e