### PR TITLE
Add generic TableOfContents and works list

### DIFF
--- a/marx_search/main.py
+++ b/marx_search/main.py
@@ -337,10 +337,21 @@ def search(
     }
 
 @app.get("/parts_with_chapters_sections")
-def get_parts_with_chapters_sections(db: Session = Depends(get_db)):
+def get_parts_with_chapters_sections(
+    work_id: int | None = Query(None),
+    db: Session = Depends(get_db),
+):
     parts = db.query(models.Part).order_by(models.Part.number).all()
-    chapters = db.query(models.Chapter).order_by(models.Chapter.id).all()
-    sections = db.query(models.Section).all()
+
+    chapters_query = db.query(models.Chapter)
+    if work_id is not None:
+        chapters_query = chapters_query.filter(models.Chapter.work_id == work_id)
+    chapters = chapters_query.order_by(models.Chapter.id).all()
+
+    sections_query = db.query(models.Section)
+    if work_id is not None:
+        sections_query = sections_query.filter(models.Section.work_id == work_id)
+    sections = sections_query.all()
 
     # Map sections to chapters
     section_map = {}
@@ -363,11 +374,12 @@ def get_parts_with_chapters_sections(db: Session = Depends(get_db)):
             if part.start_chapter <= ch.id <= part.end_chapter
         ]
 
-        result.append({
-            "number": part.number,
-            "title": part.title,
-            "chapters": part_chapters
-        })
+        if part_chapters:
+            result.append({
+                "number": part.number,
+                "title": part.title,
+                "chapters": part_chapters
+            })
 
     return result
 

--- a/marx_search_frontend/src/App.js
+++ b/marx_search_frontend/src/App.js
@@ -3,7 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Reader from "./pages/Reader";
 import Glossary from "./pages/Glossary";
 import TermDetail from "./pages/TermDetail";
-import Home from "./Home";
+import WorksList from "./pages/WorksList";
+import WorkTableOfContents from "./pages/WorkTableOfContents";
 import NavBar from "./NavBar";
 import SearchResults from "./pages/SearchResults";
 
@@ -12,12 +13,13 @@ export default function App() {
     <Router>
       <NavBar />
       <Routes>
-        <Route path="*" element={<Home />} />
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<WorksList />} />
+        <Route path="/works/:workId" element={<WorkTableOfContents />} />
         <Route path="/read/:chapterId" element={<Reader />} />
         <Route path="/terms" element={<Glossary />} />
         <Route path="/terms/:termId" element={<TermDetail />} />
         <Route path="/search" element={<SearchResults />} />
+        <Route path="*" element={<WorksList />} />
       </Routes>
     </Router>
   );

--- a/marx_search_frontend/src/components/TableOfContents.js
+++ b/marx_search_frontend/src/components/TableOfContents.js
@@ -1,30 +1,26 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { WorkContext } from "./work/WorkContext";
 
-export default function Home() {
+export default function TableOfContents({ workId }) {
   const [parts, setParts] = useState([]);
-  const { works, currentWorkId } = useContext(WorkContext);
-  const currentWork = works.find((w) => w.id === currentWorkId);
 
   useEffect(() => {
-    fetch("http://localhost:8000/parts_with_chapters_sections")
+    const url = new URL("http://localhost:8000/parts_with_chapters_sections");
+    if (workId) {
+      url.searchParams.set("work_id", workId);
+    }
+    fetch(url)
       .then((res) => res.json())
       .then(setParts);
-  }, [currentWorkId]);
+  }, [workId]);
 
   return (
-    <div className="p-6 bg-[#fceedd] dark:bg-[#1e1e1e] min-h-screen text-gray-800 dark:text-gray-200 font-serif">
-      <h1 className="text-3xl font-bold mb-8">
-        {currentWork ? currentWork.title : "Marx Texts"}
-      </h1>
-
+    <div>
       {parts.map((part) => (
         <div key={part.number} className="mb-10">
           <h2 className="text-2xl font-semibold mb-3">
             Part {part.number}: {part.title}
           </h2>
-
           <ul className="space-y-6 ml-4">
             {part.chapters.map((ch) => (
               <li key={ch.id}>

--- a/marx_search_frontend/src/pages/WorkTableOfContents.js
+++ b/marx_search_frontend/src/pages/WorkTableOfContents.js
@@ -1,0 +1,21 @@
+import React, { useContext, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import TableOfContents from "../components/TableOfContents";
+import { WorkContext } from "../work/WorkContext";
+
+export default function WorkTableOfContents() {
+  const { workId } = useParams();
+  const { setCurrentWorkId } = useContext(WorkContext);
+
+  useEffect(() => {
+    if (workId) {
+      setCurrentWorkId(parseInt(workId, 10));
+    }
+  }, [workId, setCurrentWorkId]);
+
+  return (
+    <div className="p-6 bg-[#fceedd] dark:bg-[#1e1e1e] min-h-screen text-gray-800 dark:text-gray-200 font-serif">
+      <TableOfContents workId={parseInt(workId, 10)} />
+    </div>
+  );
+}

--- a/marx_search_frontend/src/pages/WorksList.js
+++ b/marx_search_frontend/src/pages/WorksList.js
@@ -1,0 +1,32 @@
+import React, { useContext } from "react";
+import { Link } from "react-router-dom";
+import { WorkContext } from "../work/WorkContext";
+
+export default function WorksList() {
+  const { works, setCurrentWorkId } = useContext(WorkContext);
+
+  return (
+    <div className="p-6 bg-[#fceedd] dark:bg-[#1e1e1e] min-h-screen text-gray-800 dark:text-gray-200 font-serif">
+      <h1 className="text-3xl font-bold mb-8">Available Texts</h1>
+      <ul className="space-y-6">
+        {works.map((work) => (
+          <li key={work.id}>
+            <Link
+              to={`/works/${work.id}`}
+              onClick={() => setCurrentWorkId(work.id)}
+              className="text-xl text-blue-700 dark:text-blue-400 hover:underline font-medium"
+            >
+              {work.title}
+            </Link>
+            {work.author && (
+              <span className="ml-2 text-gray-600 dark:text-gray-400">{work.author}</span>
+            )}
+            {work.description && (
+              <p className="ml-4 text-gray-700 dark:text-gray-300 text-sm">{work.description}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable `TableOfContents` component
- add pages to list works and show a work's contents
- update routes to use new pages
- support optional `work_id` for `/parts_with_chapters_sections` endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475ce999cc832caf661d63f8376b1e