### PR TITLE
Add footnote API model and endpoint

### DIFF
--- a/marx_search/main.py
+++ b/marx_search/main.py
@@ -150,6 +150,17 @@ def count_term_links(term_id: str, work_id: int = Query(None), db: Session = Dep
     return {"count": count}
 
 
+@app.get("/passages/{passage_id}/footnotes", response_model=list[schemas.FootnoteOut])
+def get_passage_footnotes(passage_id: str, db: Session = Depends(get_db)):
+    footnotes = (
+        db.query(models.Footnote)
+        .filter(models.Footnote.passage_id == passage_id)
+        .order_by(models.Footnote.footnote_number)
+        .all()
+    )
+    return footnotes
+
+
 @app.get("/chapters/", response_model=list[schemas.ChapterOut])
 def get_chapters(work_id: int = Query(None), db: Session = Depends(get_db)):
     query = db.query(models.Chapter)

--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -40,6 +40,16 @@ class TermPassageLinkOut(BaseModel):
         from_attributes = True
 
 
+class FootnoteOut(BaseModel):
+    id: int
+    passage_id: str
+    footnote_number: str
+    content: str
+
+    class Config:
+        from_attributes = True
+
+
 class ChapterOut(BaseModel):
     id: int
     title: str


### PR DESCRIPTION
## Summary
- add `FootnoteOut` response model
- provide API for fetching footnotes of a passage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68476b753d2c832ca2738363335e68f9