### PR TITLE
Fix superscript rendering with term links

### DIFF
--- a/marx_search_frontend/src/pages/Reader.js
+++ b/marx_search_frontend/src/pages/Reader.js
@@ -54,11 +54,38 @@ export default function Reader() {
     }
   }, [passages, highlightId]);
 
-  const renderSuperscripts = (text) => {
-    return text.replace(
-      /(?<!\w)\.(\d+)(?!\w)/g,
-      (_, num) => `<sup>${num}</sup>`
-    );
+  const renderSuperscripts = (nodes) => {
+    const regex = /(?<!\w)\.(\d+)(?!\w)/g;
+
+    const processString = (str, prefix) => {
+      const pieces = [];
+      let lastIndex = 0;
+      let match;
+      let i = 0;
+
+      while ((match = regex.exec(str)) !== null) {
+        if (match.index > lastIndex) {
+          pieces.push(str.slice(lastIndex, match.index));
+        }
+        pieces.push(
+          <sup key={`${prefix}-${i++}`}>{match[1]}</sup>
+        );
+        lastIndex = match.index + match[0].length;
+      }
+      if (lastIndex < str.length) {
+        pieces.push(str.slice(lastIndex));
+      }
+      return pieces;
+    };
+
+    const arr = Array.isArray(nodes) ? nodes : [nodes];
+    let supIndex = 0;
+    return arr.flatMap((node) => {
+      if (typeof node === "string") {
+        return processString(node, `sup-${supIndex++}`);
+      }
+      return node;
+    });
   };
 
   const linkifyTerms = (text, terms) => {
@@ -203,7 +230,7 @@ export default function Reader() {
                     : null}
                 </div>
               )}
-              <div>{linkifyTerms(renderSuperscripts(p.text), terms)}</div>
+              <div>{renderSuperscripts(linkifyTerms(p.text, terms))}</div>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- update `renderSuperscripts` to output React nodes instead of HTML strings
- process term links before converting dotted numbers into `<sup>` elements

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476b7825c8832c9dd1145b170673da