### PR TITLE
Add footnote support

### DIFF
--- a/marx_search/main.py
+++ b/marx_search/main.py
@@ -224,6 +224,16 @@ def get_chapter_data(
     }
 
 
+@app.get("/passages/{passage_id}/footnotes", response_model=list[schemas.FootnoteOut])
+def get_passage_footnotes(passage_id: str, db: Session = Depends(get_db)):
+    return (
+        db.query(models.Footnote)
+        .filter(models.Footnote.passage_id == passage_id)
+        .order_by(models.Footnote.footnote_number)
+        .all()
+    )
+
+
 
 
 

--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -40,6 +40,16 @@ class TermPassageLinkOut(BaseModel):
         from_attributes = True
 
 
+class FootnoteOut(BaseModel):
+    id: int
+    passage_id: str
+    footnote_number: str
+    content: str
+
+    class Config:
+        from_attributes = True
+
+
 class ChapterOut(BaseModel):
     id: int
     title: str


### PR DESCRIPTION
## Summary
- expose `/passages/{passage_id}/footnotes` API endpoint
- add `FootnoteOut` Pydantic schema
- fetch passage footnotes in `Reader` page
- render footnote links and list under each passage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476b7e766c832c9a18b573b1170568