### PR TITLE
Fix global chapter ID generation

### DIFF
--- a/marx_search/parser.py
+++ b/marx_search/parser.py
@@ -7,7 +7,7 @@ import re
 from lxml import etree
 from docx import Document
 from docx.oxml.ns import qn
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, text, func
 from sqlalchemy.orm import sessionmaker
 from models import (
     Base,
@@ -155,11 +155,8 @@ def parse_and_store(docx_path, work):
     existing_chapters = {
         c.title: c for c in session.query(Chapter).filter_by(work_id=work.id).all()
     }
-    chapter_id = (
-        1
-        if not existing_chapters
-        else max(c.id for c in existing_chapters.values()) + 1
-    )
+    max_id = session.query(func.max(Chapter.id)).scalar() or 0
+    chapter_id = max_id + 1
     paragraph_id = 1
     chapter_title = f"Chapter {chapter_id}"
     chapter = existing_chapters.get(chapter_title)

--- a/marx_search/scrape_marxists.py
+++ b/marx_search/scrape_marxists.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 import requests
 from bs4 import BeautifulSoup
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker
 
 from models import Base, Work, Chapter, Section, Passage
@@ -116,8 +116,8 @@ def scrape_work(
 
     work = get_or_create_work(session, title, author, year, description)
 
-    existing_chapters = session.query(Chapter).filter_by(work_id=work.id).all()
-    next_id = 1 if not existing_chapters else max(c.id for c in existing_chapters) + 1
+    max_id = session.query(func.max(Chapter.id)).scalar() or 0
+    next_id = max_id + 1
 
     counts = {"chapters": 0, "sections": 0, "passages": 0}
     for link in links:


### PR DESCRIPTION
## Summary
- import `func` from SQLAlchemy
- use global max chapter id when determining next chapter id in scraper and parser

## Testing
- `python -m compileall marx_search`

------
https://chatgpt.com/codex/tasks/task_e_6847a4d3770c832ca64c510daf2d70ce