### PR TITLE
Add session rollback for scraping failures

### DIFF
--- a/marx_search/scrape_marxists.py
+++ b/marx_search/scrape_marxists.py
@@ -126,6 +126,7 @@ def scrape_work(
             next_id += 1
         except Exception as e:
             print(f"⚠️  Failed to scrape {link}: {e}")
+            session.rollback()
 
     print(
         f"Ready to insert {counts['chapters']} chapters, {counts['sections']} sections,"


### PR DESCRIPTION
## Summary
- add `session.rollback()` to the `except` block in `scrape_work`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a4d4f998832c8a44e4b75b8edf1e