### PR TITLE
Improve table of contents endpoint

### DIFF
--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -105,6 +105,22 @@ class PartOut(BaseModel):
         from_attributes = True
 
 
+class SectionMeta(BaseModel):
+    """Minimal section info for the table of contents."""
+
+    section: int
+    title: str
+
+
+class ChapterTOC(BaseModel):
+    """Chapter info with optional part data and section list."""
+
+    id: int
+    title: str
+    sections: list[SectionMeta]
+    part: PartInfo | None = None
+
+
 class WorkOut(BaseModel):
     id: int
     title: str


### PR DESCRIPTION
## Summary
- add schemas for sections and chapter TOC
- create `/chapters_with_sections` endpoint returning chapters with optional part info
- adjust TableOfContents component to group chapters by part when present

## Testing
- `python3 -m py_compile marx_search/main.py marx_search/schemas.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847aad33608832c803006cc1f028793