### PR TITLE
Add chapter_number support

### DIFF
--- a/marx_search/main.py
+++ b/marx_search/main.py
@@ -75,6 +75,7 @@ def get_term_links(
             models.Passage.paragraph,
             models.Passage.text,
             models.Chapter.title.label("chapter_title"),
+            models.Chapter.chapter_number.label("chapter_number"),
             models.Section.title.label("section_title"),
         )
         .join(models.Passage, models.Passage.id == models.TermPassageLink.passage_id)
@@ -98,6 +99,7 @@ def get_term_links(
             "paragraph": row.paragraph,
             "text_snippet": extract_context_snippet(row.text, term_id),
             "chapter_title": row.chapter_title,
+            "chapter_number": row.chapter_number if hasattr(row, "chapter_number") else None,
             "section_title": row.section_title,
             "work_id": row.work_id
         })
@@ -204,6 +206,7 @@ def get_chapter_data(
 
     return {
         "title": chapter.title,
+        "chapter_number": chapter.chapter_number,
         "passages": passages,
         "sections": sections,
         "terms": terms,
@@ -213,11 +216,13 @@ def get_chapter_data(
         } if part else None,
         "prev_chapter": {
             "id": prev_chapter.id,
+            "chapter_number": prev_chapter.chapter_number,
             "title": prev_chapter.title,
             "work_id": prev_chapter.work_id
         } if prev_chapter else None,
         "next_chapter": {
             "id": next_chapter.id,
+            "chapter_number": next_chapter.chapter_number,
             "title": next_chapter.title,
             "work_id": next_chapter.work_id
         } if next_chapter else None
@@ -295,6 +300,7 @@ def search(
             "text_snippet": extract_context_snippet(p.text, q),
             "translation": p.translation,
             "chapter_title": chapter.title if chapter else None,
+            "chapter_number": chapter.chapter_number if chapter else None,
             "section_title": section.title if section else None,
             "work_id": p.work_id,
         })
@@ -340,6 +346,7 @@ def get_parts_with_chapters_sections(
             {
                 "id": ch.id,
                 "title": ch.title,
+                "chapter_number": ch.chapter_number,
                 "sections": section_map.get(ch.id, [])
             }
             for ch in chapters
@@ -393,6 +400,7 @@ def get_chapters_with_sections(
             {
                 "id": ch.id,
                 "title": ch.title,
+                "chapter_number": ch.chapter_number,
                 "sections": section_map.get(ch.id, []),
                 "part": part_for(ch.id),
             }

--- a/marx_search/models.py
+++ b/marx_search/models.py
@@ -37,6 +37,7 @@ class Chapter(Base):
 
     id = Column(Integer, primary_key=True)
     title = Column(String, nullable=False)
+    chapter_number = Column(Integer, nullable=True)
     work_id = Column(Integer, ForeignKey("works.id"), nullable=False)
     work = relationship("Work", backref="chapters")
 

--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -59,6 +59,7 @@ class TermPassageLinkOut(BaseModel):
 class ChapterOut(BaseModel):
     id: int
     title: str
+    chapter_number: int | None = None
     work_id: int
 
     class Config:
@@ -79,6 +80,7 @@ class SectionOut(BaseModel):
 class ChapterNavOut(BaseModel):
     id: int
     title: str
+    chapter_number: int | None = None
     work_id: int
 
 class PartInfo(BaseModel):
@@ -87,6 +89,7 @@ class PartInfo(BaseModel):
 
 class ChapterDataOut(BaseModel):
     title: str
+    chapter_number: int | None = None
     passages: List[PassageOut]
     sections: List[SectionOut]
     terms: List[TermOut]
@@ -117,6 +120,7 @@ class ChapterTOC(BaseModel):
 
     id: int
     title: str
+    chapter_number: int | None = None
     sections: list[SectionMeta]
     part: PartInfo | None = None
 

--- a/marx_search/update_chapter_numbers.py
+++ b/marx_search/update_chapter_numbers.py
@@ -1,0 +1,77 @@
+import requests
+from bs4 import BeautifulSoup
+from sqlalchemy import create_engine, text, func
+from sqlalchemy.orm import sessionmaker
+from models import Chapter, Section, Passage, Work
+from scrape_marxists import parse_page
+
+engine = create_engine("sqlite:///marx_texts.db")
+Session = sessionmaker(bind=engine)
+
+# Helper to ensure column exists
+with engine.connect() as conn:
+    cols = [row[1] for row in conn.execute(text("PRAGMA table_info(chapters)")).fetchall()]
+    if "chapter_number" not in cols:
+        conn.execute(text("ALTER TABLE chapters ADD COLUMN chapter_number INTEGER"))
+
+
+def main():
+    session = Session()
+
+    # 1-33
+    for ch in session.query(Chapter).filter(Chapter.id.between(1, 33)).order_by(Chapter.id):
+        num = ch.id
+        ch.chapter_number = num
+        if not ch.title.startswith(f"Chapter {num}:"):
+            ch.title = f"Chapter {num}: {ch.title}"
+
+    # delete 34-100
+    del_ids = list(range(34, 101))
+    session.query(Passage).filter(Passage.chapter.in_(del_ids)).delete(synchronize_session=False)
+    session.query(Section).filter(Section.chapter.in_(del_ids)).delete(synchronize_session=False)
+    session.query(Chapter).filter(Chapter.id.in_(del_ids)).delete(synchronize_session=False)
+
+    # 101-105
+    chs = session.query(Chapter).filter(Chapter.id.between(101, 105)).order_by(Chapter.id).all()
+    for i, ch in enumerate(chs, start=1):
+        ch.chapter_number = i
+
+    # 107-113
+    chs = session.query(Chapter).filter(Chapter.id.between(107, 113)).order_by(Chapter.id).all()
+    for i, ch in enumerate(chs, start=1):
+        ch.chapter_number = i
+
+    # 114-137
+    session.query(Chapter).filter(Chapter.id == 135).delete(synchronize_session=False)
+    chs = session.query(Chapter).filter(Chapter.id.between(114, 137)).order_by(Chapter.id).all()
+    for i, ch in enumerate(chs, start=1):
+        ch.chapter_number = i
+
+    # scrape missing chapter parts for volume II
+    work = session.query(Work).filter(Work.title == "Capital, Volume II").first()
+    if work:
+        urls = [
+            "https://www.marxists.org/archive/marx/works/1885-c2/ch20_01.htm",
+            "https://www.marxists.org/archive/marx/works/1885-c2/ch20_02.htm",
+            "https://www.marxists.org/archive/marx/works/1885-c2/ch20_03.htm",
+            "https://www.marxists.org/archive/marx/works/1885-c2/ch20_04.htm",
+            "https://www.marxists.org/archive/marx/works/1885-c2/ch21_01.htm",
+            "https://www.marxists.org/archive/marx/works/1885-c2/ch21_02.htm",
+        ]
+        max_id = session.query(func.max(Chapter.id)).scalar() or 0
+        next_id = max_id + 1
+        counts = {"chapters":0, "sections":0, "passages":0}
+        for url in urls:
+            parse_page(session, url, next_id, work, counts)
+            next_id += 1
+
+    # 138-193
+    chs = session.query(Chapter).filter(Chapter.id.between(138, 193)).order_by(Chapter.id).all()
+    for i, ch in enumerate(chs, start=1):
+        ch.chapter_number = i
+
+    session.commit()
+    session.close()
+
+if __name__ == "__main__":
+    main()

--- a/marx_search_frontend/src/pages/Reader.js
+++ b/marx_search_frontend/src/pages/Reader.js
@@ -9,6 +9,7 @@ export default function Reader() {
   const highlightId = searchParams.get("highlight");
 
   const [chapterTitle, setChapterTitle] = useState("");
+  const [chapterNumber, setChapterNumber] = useState(null);
   const [part, setPart] = useState(null);
   const [passages, setPassages] = useState([]);
   const [sectionsMeta, setSectionsMeta] = useState([]);
@@ -30,6 +31,7 @@ export default function Reader() {
         setSectionsMeta(data.sections);
         setTerms(data.terms);
         setChapterTitle(data.title);
+        setChapterNumber(data.chapter_number);
         setPart(data.part);
         setPrevChapter(data.prev_chapter);
         setNextChapter(data.next_chapter);
@@ -158,7 +160,7 @@ export default function Reader() {
 
         <div className="flex justify-between items-center flex-wrap gap-3 mb-3">
           <h1 className="text-3xl font-bold">
-            Chapter {parseInt(chapterId, 10)}: {chapterTitle}
+            Chapter {chapterNumber ?? parseInt(chapterId, 10)}: {chapterTitle}
           </h1>
           <div className="flex gap-4 text-sm flex-wrap">
             {prevChapter && (
@@ -261,7 +263,7 @@ export default function Reader() {
                   className="text-blue-600 hover:underline"
                   onClick={() => setShowChapterMenu(false)}
                 >
-                  Chapter {ch.id}: {ch.title}
+                  Chapter {ch.chapter_number ?? ch.id}: {ch.title}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- add `chapter_number` column to `Chapter`
- expose chapter numbers in API schemas and endpoints
- update Reader front-end to display `chapter_number`
- script to update existing chapter data

## Testing
- `npm test` *(fails: Missing script)*
- `pytest` *(runs, no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b991c150832c990c8066c88b6fc3