### PR TITLE
Use per-work chapter numbers

### DIFF
--- a/marx_search/fix_volume1_titles.py
+++ b/marx_search/fix_volume1_titles.py
@@ -1,0 +1,26 @@
+import re
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+engine = create_engine("sqlite:///marx_texts.db")
+Session = sessionmaker(bind=engine)
+
+
+def main():
+    with Session() as session:
+        work = session.execute(text("SELECT id FROM works WHERE title = :t"), {"t": "Capital, Volume I"}).fetchone()
+        if not work:
+            print("Work not found")
+            return
+        wid = work[0]
+        chapters = session.execute(text("SELECT id, title FROM chapters WHERE work_id = :wid ORDER BY id"), {"wid": wid}).fetchall()
+        for num, (cid, title) in enumerate(chapters, start=1):
+            m = re.match(r"chapter\s*\d+[:.]\s*(.*)", title, flags=re.I)
+            new_title = m.group(1).strip() if m else title
+            session.execute(text("UPDATE chapters SET title = :title, number = :num WHERE id = :cid"), {"title": new_title, "num": num, "cid": cid})
+        session.commit()
+        print(f"Updated {len(chapters)} chapter titles for Volume I")
+
+
+if __name__ == "__main__":
+    main()

--- a/marx_search/models.py
+++ b/marx_search/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -36,8 +36,10 @@ class Chapter(Base):
     __tablename__ = "chapters"
 
     id = Column(Integer, primary_key=True)
+    number = Column(Integer, nullable=False)
     title = Column(String, nullable=False)
     work_id = Column(Integer, ForeignKey("works.id"), nullable=False)
+    __table_args__ = (UniqueConstraint("work_id", "number"),)
     work = relationship("Work", backref="chapters")
 
 

--- a/marx_search/parser.py
+++ b/marx_search/parser.py
@@ -161,7 +161,7 @@ def parse_and_store(docx_path, work):
     chapter_title = f"Chapter {chapter_id}"
     chapter = existing_chapters.get(chapter_title)
     if not chapter:
-        chapter = Chapter(id=chapter_id, title=chapter_title, work_id=work.id)
+        chapter = Chapter(id=chapter_id, number=chapter_id, title=chapter_title, work_id=work.id)
         session.add(chapter)
         session.commit()
     else:
@@ -207,7 +207,7 @@ def parse_and_store(docx_path, work):
             chapter_title = plain_text
             chapter = existing_chapters.get(chapter_title)
             if not chapter:
-                chapter = Chapter(id=chapter_id, title=chapter_title, work_id=work.id)
+                chapter = Chapter(id=chapter_id, number=chapter_id, title=chapter_title, work_id=work.id)
                 session.add(chapter)
                 session.commit()
                 existing_chapters[chapter_title] = chapter

--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -57,7 +57,7 @@ class TermPassageLinkOut(BaseModel):
 
 
 class ChapterOut(BaseModel):
-    id: int
+    number: int
     title: str
     work_id: int
 
@@ -77,7 +77,7 @@ class SectionOut(BaseModel):
 
 
 class ChapterNavOut(BaseModel):
-    id: int
+    number: int
     title: str
     work_id: int
 
@@ -115,7 +115,7 @@ class SectionMeta(BaseModel):
 class ChapterTOC(BaseModel):
     """Chapter info with optional part data and section list."""
 
-    id: int
+    number: int
     title: str
     sections: list[SectionMeta]
     part: PartInfo | None = None

--- a/marx_search/seed_parts.py
+++ b/marx_search/seed_parts.py
@@ -42,7 +42,7 @@ def main():
             chapters = (
                 session.query(Chapter)
                 .filter(Chapter.work_id == work.id)
-                .order_by(Chapter.id)
+                .order_by(Chapter.number)
                 .all()
             )
             num_to_id = {i + 1: ch.id for i, ch in enumerate(chapters)}

--- a/marx_search_frontend/src/components/TableOfContents.js
+++ b/marx_search_frontend/src/components/TableOfContents.js
@@ -37,19 +37,19 @@ export default function TableOfContents({ workId }) {
           )}
           <ul className="space-y-6 ml-4">
             {group.chapters.map((ch) => (
-              <li key={ch.id}>
+              <li key={ch.number}>
                 <Link
-                  to={`/read/${workId || 1}/${ch.id}`}
+                  to={`/read/${workId || 1}/${ch.number}`}
                   className="text-xl text-blue-700 dark:text-blue-400 hover:underline font-medium"
                 >
-                  Chapter {ch.id}: {ch.title}
+                  Chapter {ch.number}: {ch.title}
                 </Link>
                 {ch.sections.length > 0 && (
                   <ul className="ml-6 mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-300">
                     {ch.sections.map((sec) => (
                       <li key={sec.section}>
                         <Link
-                          to={`/read/${workId || 1}/${ch.id}#section-${sec.section}`}
+                          to={`/read/${workId || 1}/${ch.number}#section-${sec.section}`}
                           className="hover:underline"
                         >
                           Section {sec.section}: {sec.title}

--- a/marx_search_frontend/src/pages/Reader.js
+++ b/marx_search_frontend/src/pages/Reader.js
@@ -163,7 +163,7 @@ export default function Reader() {
           <div className="flex gap-4 text-sm flex-wrap">
             {prevChapter && (
               <Link
-                to={`/read/${prevChapter.work_id}/${prevChapter.id}`}
+                to={`/read/${prevChapter.work_id}/${prevChapter.number}`}
                 className="text-blue-600 hover:underline"
               >
                 ← {prevChapter.title}
@@ -171,7 +171,7 @@ export default function Reader() {
             )}
             {nextChapter && (
               <Link
-                to={`/read/${nextChapter.work_id}/${nextChapter.id}`}
+                to={`/read/${nextChapter.work_id}/${nextChapter.number}`}
                 className="text-blue-600 hover:underline"
               >
                 {nextChapter.title} →
@@ -212,7 +212,7 @@ export default function Reader() {
         <div className="flex justify-between items-center border-t pt-4 mt-8 text-sm">
           {prevChapter ? (
             <Link
-              to={`/read/${prevChapter.work_id}/${prevChapter.id}`}
+              to={`/read/${prevChapter.work_id}/${prevChapter.number}`}
               className="text-blue-600 hover:underline"
             >
               ← {prevChapter.title}
@@ -222,7 +222,7 @@ export default function Reader() {
           )}
           {nextChapter && (
             <Link
-              to={`/read/${nextChapter.work_id}/${nextChapter.id}`}
+              to={`/read/${nextChapter.work_id}/${nextChapter.number}`}
               className="text-blue-600 hover:underline"
             >
               {nextChapter.title} →
@@ -255,13 +255,13 @@ export default function Reader() {
           </h3>
           <ul className="space-y-1">
             {allChapters.map((ch) => (
-              <li key={ch.id}>
+              <li key={ch.number}>
                 <Link
-                  to={`/read/${workId}/${ch.id}`}
+                  to={`/read/${workId}/${ch.number}`}
                   className="text-blue-600 hover:underline"
                   onClick={() => setShowChapterMenu(false)}
                 >
-                  Chapter {ch.id}: {ch.title}
+                  Chapter {ch.number}: {ch.title}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- add `number` to chapter model and migrations
- update API to use chapter numbers per work
- adjust scraper, parser and seed scripts for new number field
- fix React reader and table of contents for per-work chapters
- provide helper script to clean Volume I titles

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847ae58c8d8832ca060c84c48bc33be