### PR TITLE
Fix chapter scraping and numbering

### DIFF
--- a/marx_search/scrape_marxists.py
+++ b/marx_search/scrape_marxists.py
@@ -55,7 +55,14 @@ def parse_page(session, url: str, chapter_id: int, work: Work, counts: dict):
     page.raise_for_status()
     soup = BeautifulSoup(page.text, "html.parser")
 
-    header = soup.find(["h1", "h2", "h3"])
+    header = None
+    for h in soup.find_all(["h1", "h2", "h3"]):
+        text = h.get_text(strip=True)
+        if not re.match(r"(?i)part\b", text):
+            header = h
+            break
+    if not header:
+        header = soup.find(["h1", "h2", "h3"])
     chapter_title = header.get_text(strip=True) if header else os.path.basename(url)
 
     chapter = Chapter(id=chapter_id, title=chapter_title, work_id=work.id)

--- a/marx_search/update_chapter_numbers.py
+++ b/marx_search/update_chapter_numbers.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from sqlalchemy import create_engine, text, func
 from sqlalchemy.orm import sessionmaker
 from models import Chapter, Section, Passage, Work
-from scrape_marxists import parse_page
+from scrape_marxists import parse_page, links_capital_vol3
 
 engine = create_engine("sqlite:///marx_texts.db")
 Session = sessionmaker(bind=engine)
@@ -60,15 +60,51 @@ def main():
         ]
         max_id = session.query(func.max(Chapter.id)).scalar() or 0
         next_id = max_id + 1
-        counts = {"chapters":0, "sections":0, "passages":0}
+        counts = {"chapters": 0, "sections": 0, "passages": 0}
         for url in urls:
             parse_page(session, url, next_id, work, counts)
             next_id += 1
 
-    # 138-193
-    chs = session.query(Chapter).filter(Chapter.id.between(138, 193)).order_by(Chapter.id).all()
+    # remove and re-scrape incorrect chapters for Capital Volume III
+    del_ids = list(range(138, 191))
+    session.query(Passage).filter(Passage.chapter.in_(del_ids)).delete(synchronize_session=False)
+    session.query(Section).filter(Section.chapter.in_(del_ids)).delete(synchronize_session=False)
+    session.query(Chapter).filter(Chapter.id.in_(del_ids)).delete(synchronize_session=False)
+
+    work_v3 = session.query(Work).filter(Work.title == "Capital, Volume III").first()
+    if work_v3:
+        urls = links_capital_vol3("https://www.marxists.org/archive/marx/works/1894-c3/")
+        max_id = session.query(func.max(Chapter.id)).scalar() or 0
+        next_id = max_id + 1
+        counts = {"chapters": 0, "sections": 0, "passages": 0}
+        for url in urls:
+            parse_page(session, url, next_id, work_v3, counts)
+            next_id += 1
+
+    # 138-199
+    chs = session.query(Chapter).filter(Chapter.id.between(138, 199)).order_by(Chapter.id).all()
     for i, ch in enumerate(chs, start=1):
         ch.chapter_number = i
+
+    # custom updates
+    updates = {
+        106: ("Appendix", 6),
+        194: ("Chapter 20: Simple Reproduction Part 1", 22),
+        195: ("Chapter 20: Simple Reproduction Part 2", 23),
+        196: ("Chapter 20: Simple Reproduction Part 3", 24),
+        197: ("Chapter 20: Simple Reproduction Part 4", 25),
+        198: ("Chapter 21: Accumulation and Reproduction on an Extended Scale", 26),
+        199: ("Chapter 21: Accumulation and Reproduction on an Extended Scale", 27),
+    }
+    for cid, (title, num) in updates.items():
+        ch = session.get(Chapter, cid)
+        if ch:
+            ch.title = title
+            ch.chapter_number = num
+
+    session.query(Passage).filter(Passage.chapter.in_([136, 137])).delete(synchronize_session=False)
+    session.query(Section).filter(Section.chapter.in_([136, 137])).delete(synchronize_session=False)
+    session.query(Chapter).filter(Chapter.id.in_([136, 137])).delete(synchronize_session=False)
 
     session.commit()
     session.close()


### PR DESCRIPTION
## Summary
- skip "Part" headers when parsing chapter titles
- rescrape and renumber chapters for Capital Vol. III
- add fixes for specific chapter titles and numbers

## Testing
- `python -m py_compile marx_search/update_chapter_numbers.py marx_search/scrape_marxists.py`
- `npm test --silent` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847bf7d96f0832ca9fd5679a7f3fe08