### PR TITLE
Use chapter_number for navigation

### DIFF
--- a/marx_search/schemas.py
+++ b/marx_search/schemas.py
@@ -2,6 +2,7 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+
 class PassageOut(BaseModel):
     id: str
     chapter: int
@@ -17,6 +18,7 @@ class PassageOut(BaseModel):
 
 class PassageSearchOut(BaseModel):
     """Passage information returned from the search endpoint."""
+
     id: str
     chapter: int
     section: int | None = None
@@ -29,6 +31,7 @@ class PassageSearchOut(BaseModel):
 
     class Config:
         from_attributes = True
+
 
 class TermOut(BaseModel):
     id: str
@@ -79,12 +82,15 @@ class SectionOut(BaseModel):
 
 class ChapterNavOut(BaseModel):
     id: int
+    chapter_number: int
     title: str
     work_id: int
+
 
 class PartInfo(BaseModel):
     number: int
     title: str
+
 
 class ChapterDataOut(BaseModel):
     title: str
@@ -94,7 +100,6 @@ class ChapterDataOut(BaseModel):
     part: PartInfo | None = None
     prev_chapter: ChapterNavOut | None = None
     next_chapter: ChapterNavOut | None = None
-
 
 
 class PartOut(BaseModel):
@@ -117,6 +122,7 @@ class ChapterTOC(BaseModel):
     """Chapter info with optional part data and section list."""
 
     id: int
+    chapter_number: int
     title: str
     sections: list[SectionMeta]
     part: PartInfo | None = None

--- a/marx_search_frontend/src/App.js
+++ b/marx_search_frontend/src/App.js
@@ -15,7 +15,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<WorksList />} />
         <Route path="/works/:workId" element={<WorkTableOfContents />} />
-        <Route path="/read/:workId/:chapterId" element={<Reader />} />
+        <Route path="/read/:workId/:chapterNumber" element={<Reader />} />
         <Route path="/terms" element={<Glossary />} />
         <Route path="/terms/:termId" element={<TermDetail />} />
         <Route path="/search" element={<SearchResults />} />

--- a/marx_search_frontend/src/components/TableOfContents.js
+++ b/marx_search_frontend/src/components/TableOfContents.js
@@ -39,17 +39,17 @@ export default function TableOfContents({ workId }) {
             {group.chapters.map((ch) => (
               <li key={ch.id}>
                 <Link
-                  to={`/read/${workId || 1}/${ch.id}`}
+                  to={`/read/${workId || 1}/${ch.chapter_number}`}
                   className="text-xl text-blue-700 dark:text-blue-400 hover:underline font-medium"
                 >
-                  Chapter {ch.id}: {ch.title}
+                  Chapter {ch.chapter_number}: {ch.title}
                 </Link>
                 {ch.sections.length > 0 && (
                   <ul className="ml-6 mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-300">
                     {ch.sections.map((sec) => (
                       <li key={sec.section}>
                         <Link
-                          to={`/read/${workId || 1}/${ch.id}#section-${sec.section}`}
+                          to={`/read/${workId || 1}/${ch.chapter_number}#section-${sec.section}`}
                           className="hover:underline"
                         >
                           Section {sec.section}: {sec.title}

--- a/marx_search_frontend/src/pages/Reader.js
+++ b/marx_search_frontend/src/pages/Reader.js
@@ -4,7 +4,7 @@ import DarkModeToggleFloating from "../darkmode/DarkModeToggleFloating";
 import { WorkContext } from "../work/WorkContext";
 
 export default function Reader() {
-  const { workId, chapterId } = useParams();
+  const { workId, chapterNumber } = useParams();
   const [searchParams] = useSearchParams();
   const highlightId = searchParams.get("highlight");
 
@@ -21,8 +21,9 @@ export default function Reader() {
 
   useEffect(() => {
     setCurrentWorkId(parseInt(workId, 10));
-    const chapterUrl = new URL(`http://localhost:8000/chapter_data/${parseInt(chapterId, 10)}`);
-    chapterUrl.searchParams.set("work_id", workId);
+    const chapterUrl = new URL(
+      `http://localhost:8000/chapter_data/${workId}/${parseInt(chapterNumber, 10)}`
+    );
     fetch(chapterUrl)
       .then((res) => res.json())
       .then((data) => {
@@ -39,7 +40,7 @@ export default function Reader() {
     fetch(chaptersUrl)
       .then((res) => res.json())
       .then(setAllChapters);
-  }, [workId, chapterId]);
+  }, [workId, chapterNumber]);
 
   useEffect(() => {
     if (highlightId) {
@@ -158,12 +159,12 @@ export default function Reader() {
 
         <div className="flex justify-between items-center flex-wrap gap-3 mb-3">
           <h1 className="text-3xl font-bold">
-            Chapter {parseInt(chapterId, 10)}: {chapterTitle}
+            Chapter {parseInt(chapterNumber, 10)}: {chapterTitle}
           </h1>
           <div className="flex gap-4 text-sm flex-wrap">
             {prevChapter && (
               <Link
-                to={`/read/${prevChapter.work_id}/${prevChapter.id}`}
+                to={`/read/${prevChapter.work_id}/${prevChapter.chapter_number}`}
                 className="text-blue-600 hover:underline"
               >
                 ← {prevChapter.title}
@@ -171,7 +172,7 @@ export default function Reader() {
             )}
             {nextChapter && (
               <Link
-                to={`/read/${nextChapter.work_id}/${nextChapter.id}`}
+                to={`/read/${nextChapter.work_id}/${nextChapter.chapter_number}`}
                 className="text-blue-600 hover:underline"
               >
                 {nextChapter.title} →
@@ -212,7 +213,7 @@ export default function Reader() {
         <div className="flex justify-between items-center border-t pt-4 mt-8 text-sm">
           {prevChapter ? (
             <Link
-              to={`/read/${prevChapter.work_id}/${prevChapter.id}`}
+              to={`/read/${prevChapter.work_id}/${prevChapter.chapter_number}`}
               className="text-blue-600 hover:underline"
             >
               ← {prevChapter.title}
@@ -222,7 +223,7 @@ export default function Reader() {
           )}
           {nextChapter && (
             <Link
-              to={`/read/${nextChapter.work_id}/${nextChapter.id}`}
+              to={`/read/${nextChapter.work_id}/${nextChapter.chapter_number}`}
               className="text-blue-600 hover:underline"
             >
               {nextChapter.title} →
@@ -257,11 +258,11 @@ export default function Reader() {
             {allChapters.map((ch) => (
               <li key={ch.id}>
                 <Link
-                  to={`/read/${workId}/${ch.id}`}
+                  to={`/read/${workId}/${ch.chapter_number}`}
                   className="text-blue-600 hover:underline"
                   onClick={() => setShowChapterMenu(false)}
                 >
-                  Chapter {ch.id}: {ch.title}
+                  Chapter {ch.chapter_number}: {ch.title}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- extend scraper to set chapter_number when ingesting works
- update API endpoints to reference chapters by chapter_number
- adjust schemas for chapter_number in navigation
- switch frontend routes and links to use chapter_number

## Testing
- `black marx_search/scrape_marxists.py marx_search/main.py marx_search/schemas.py --line-length 79`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6848680c46d4832cb51c6b7dd4508ef0