### PR TITLE
Add paragraph renumbering helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,13 @@ Run `python marx_search/scrape_marxists.py` to automatically download a set of t
 
 After scraping new works, run `python marx_search/seed_parts.py` to populate the `parts` table. This groups chapters into logical parts for the table of contents.
 
+### Passage numbering
+
+Paragraph numbers restart at the beginning of each chapter.  Sections are
+recorded only for the table of contents and do not affect numbering.  If you
+imported data with per‑section numbering, run `python marx_search/renumber_passages.py`
+to rewrite the passage IDs and paragraph fields so they are sequential within
+each chapter.
+
 Currently the project contains no automated tests. Potential improvements include adding tests and expanding these instructions further.
 

--- a/marx_search/renumber_passages.py
+++ b/marx_search/renumber_passages.py
@@ -1,0 +1,41 @@
+import re
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from models import Passage, TermPassageLink, Chapter
+
+# Adjust the DB URL if needed
+engine = create_engine("sqlite:///marx_texts.db")
+Session = sessionmaker(bind=engine)
+
+def renumber_chapter(session, chapter: Chapter):
+    """Renumber paragraphs sequentially within a chapter."""
+    passages = (
+        session.query(Passage)
+        .filter(Passage.chapter == chapter.id)
+        .order_by(Passage.paragraph)
+        .all()
+    )
+    for idx, passage in enumerate(passages, start=1):
+        if passage.paragraph == idx:
+            continue
+        old_id = passage.id
+        new_id = re.sub(r"p\d+$", f"p{idx}", old_id)
+        # Update related links
+        session.query(TermPassageLink).filter(
+            TermPassageLink.passage_id == old_id
+        ).update({"passage_id": new_id})
+        passage.id = new_id
+        passage.paragraph = idx
+    session.commit()
+
+
+def renumber_all():
+    with Session() as session:
+        chapters = session.query(Chapter).order_by(Chapter.id).all()
+        for ch in chapters:
+            renumber_chapter(session, ch)
+        print("✅ Renumbered paragraphs per chapter")
+
+
+if __name__ == "__main__":
+    renumber_all()


### PR DESCRIPTION
## Summary
- add helper script `renumber_passages.py` to renumber paragraphs sequentially per chapter
- document paragraph numbering approach in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486bf2dc20832ca5dd5afdf0823585