### PR TITLE
Fix paragraph numbering scope

### DIFF
--- a/marx_search/scrape_marxists.py
+++ b/marx_search/scrape_marxists.py
@@ -89,7 +89,14 @@ def parse_page(
     counts["chapters"] += 1
     session.flush()
 
-    paragraph_id = 1
+    # Start numbering passages after the last existing paragraph for this
+    # chapter so numbering always continues sequentially within a chapter.
+    paragraph_id = (
+        session.query(func.max(Passage.paragraph))
+        .filter(Passage.chapter == chapter_id)
+        .scalar()
+        or 0
+    ) + 1
     current_section = None
     section_count = 1
 


### PR DESCRIPTION
## Summary
- ensure `scrape_marxists` keeps numbering paragraphs sequentially within each chapter

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --prefix marx_search_frontend` *(fails: Missing script 'test')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486f70b474832cb694e525c8b670b8