### PR TITLE
Update backend URL for dev environment

### DIFF
--- a/marx_search_frontend/src/components/TableOfContents.js
+++ b/marx_search_frontend/src/components/TableOfContents.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import API_BASE_URL from "../config";
 
 export default function TableOfContents({ workId }) {
   const [chapters, setChapters] = useState([]);
 
   useEffect(() => {
-    const url = new URL("http://localhost:8000/chapters_with_sections");
+    const url = new URL("/chapters_with_sections", API_BASE_URL);
     if (workId) {
       url.searchParams.set("work_id", workId);
     }

--- a/marx_search_frontend/src/config.js
+++ b/marx_search_frontend/src/config.js
@@ -1,0 +1,6 @@
+const API_BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:8000"
+    : "http://3.142.200.52";
+
+export default API_BASE_URL;

--- a/marx_search_frontend/src/pages/Glossary.js
+++ b/marx_search_frontend/src/pages/Glossary.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import { Link } from "react-router-dom";
 import { WorkContext } from "../work/WorkContext";
+import API_BASE_URL from "../config";
 
 export default function Glossary() {
   const [terms, setTerms] = useState([]);
@@ -8,7 +9,7 @@ export default function Glossary() {
   const { currentWorkId } = useContext(WorkContext);
 
   useEffect(() => {
-    const url = new URL("http://localhost:8000/terms/");
+    const url = new URL("/terms/", API_BASE_URL);
     if (currentWorkId) {
       url.searchParams.set("work_id", currentWorkId);
     }

--- a/marx_search_frontend/src/pages/Reader.js
+++ b/marx_search_frontend/src/pages/Reader.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useContext } from "react";
 import { useParams, useSearchParams, Link } from "react-router-dom";
 import DarkModeToggleFloating from "../darkmode/DarkModeToggleFloating";
 import { WorkContext } from "../work/WorkContext";
+import API_BASE_URL from "../config";
 
 export default function Reader() {
   const { workId, chapterNumber } = useParams();
@@ -22,7 +23,8 @@ export default function Reader() {
   useEffect(() => {
     setCurrentWorkId(parseInt(workId, 10));
     const chapterUrl = new URL(
-      `http://localhost:8000/chapter_data/${workId}/${parseInt(chapterNumber, 10)}`
+      `/chapter_data/${workId}/${parseInt(chapterNumber, 10)}`,
+      API_BASE_URL
     );
     fetch(chapterUrl)
       .then((res) => res.json())
@@ -35,7 +37,7 @@ export default function Reader() {
         setPrevChapter(data.prev_chapter);
         setNextChapter(data.next_chapter);
       });
-    const chaptersUrl = new URL("http://localhost:8000/chapters/");
+    const chaptersUrl = new URL("/chapters/", API_BASE_URL);
     chaptersUrl.searchParams.set("work_id", workId);
     fetch(chaptersUrl)
       .then((res) => res.json())

--- a/marx_search_frontend/src/pages/SearchResults.js
+++ b/marx_search_frontend/src/pages/SearchResults.js
@@ -1,5 +1,6 @@
 import { useLocation, Link, useSearchParams } from "react-router-dom";
 import React, { useEffect, useState, useContext } from "react";
+import API_BASE_URL from "../config";
 import PassageSnippet from "../components/PassageSnippet";
 import Pagination from "../components/Pagination";
 import { WorkContext } from "../work/WorkContext";
@@ -23,7 +24,7 @@ export default function SearchResults() {
       if (currentWorkId) {
         params.set("work_id", currentWorkId);
       }
-      fetch(`http://localhost:8000/search?${params.toString()}`)
+      fetch(`${API_BASE_URL}/search?${params.toString()}`)
         .then((res) => res.json())
         .then((data) => {
           setResults(data);

--- a/marx_search_frontend/src/pages/TermDetail.js
+++ b/marx_search_frontend/src/pages/TermDetail.js
@@ -4,6 +4,7 @@ import DarkModeToggleFloating from "../darkmode/DarkModeToggleFloating";
 import PassageSnippet from "../components/PassageSnippet";
 import Pagination from "../components/Pagination";
 import { WorkContext } from "../work/WorkContext";
+import API_BASE_URL from "../config";
 
 export default function TermDetail() {
   const { termId } = useParams();
@@ -17,15 +18,17 @@ export default function TermDetail() {
   const { currentWorkId } = useContext(WorkContext);
 
   useEffect(() => {
-    fetch(`http://localhost:8000/terms/${termId}`)
+    fetch(`${API_BASE_URL}/terms/${termId}`)
       .then((res) => res.json())
       .then(setTerm);
 
     const countUrl = new URL(
-      `http://localhost:8000/terms/${termId}/passage_count`
+      `/terms/${termId}/passage_count`,
+      API_BASE_URL
     );
     const passagesUrl = new URL(
-      `http://localhost:8000/terms/${termId}/passages`
+      `/terms/${termId}/passages`,
+      API_BASE_URL
     );
     passagesUrl.searchParams.set("page", page);
     passagesUrl.searchParams.set("page_size", pageSize);

--- a/marx_search_frontend/src/work/WorkContext.js
+++ b/marx_search_frontend/src/work/WorkContext.js
@@ -1,4 +1,5 @@
 import React, { createContext, useEffect, useState } from "react";
+import API_BASE_URL from "../config";
 
 export const WorkContext = createContext();
 
@@ -10,7 +11,7 @@ export const WorkProvider = ({ children }) => {
   });
 
   useEffect(() => {
-    fetch("http://localhost:8000/works/")
+    fetch(`${API_BASE_URL}/works/`)
       .then((res) => res.json())
       .then(setWorks);
   }, []);


### PR DESCRIPTION
## Summary
- add a small config module exposing `API_BASE_URL`
- reference `API_BASE_URL` in all fetch calls so the frontend targets localhost during development and the EC2 server in production

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848946f05f0832ca28138391dd20668