### PR TITLE
Improve homepage design and add footer

### DIFF
--- a/marx_search_frontend/src/App.js
+++ b/marx_search_frontend/src/App.js
@@ -6,21 +6,27 @@ import TermDetail from "./pages/TermDetail";
 import WorksList from "./pages/WorksList";
 import WorkTableOfContents from "./pages/WorkTableOfContents";
 import NavBar from "./NavBar";
+import Footer from "./Footer";
 import SearchResults from "./pages/SearchResults";
 
 export default function App() {
   return (
     <Router>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<WorksList />} />
-        <Route path="/works/:workId" element={<WorkTableOfContents />} />
-        <Route path="/read/:workId/:chapterNumber" element={<Reader />} />
-        <Route path="/terms" element={<Glossary />} />
-        <Route path="/terms/:termId" element={<TermDetail />} />
-        <Route path="/search" element={<SearchResults />} />
-        <Route path="*" element={<WorksList />} />
-      </Routes>
+      <div className="flex flex-col min-h-screen">
+        <NavBar />
+        <div className="flex-grow">
+          <Routes>
+            <Route path="/" element={<WorksList />} />
+            <Route path="/works/:workId" element={<WorkTableOfContents />} />
+            <Route path="/read/:workId/:chapterNumber" element={<Reader />} />
+            <Route path="/terms" element={<Glossary />} />
+            <Route path="/terms/:termId" element={<TermDetail />} />
+            <Route path="/search" element={<SearchResults />} />
+            <Route path="*" element={<WorksList />} />
+          </Routes>
+        </div>
+        <Footer />
+      </div>
     </Router>
   );
 }

--- a/marx_search_frontend/src/Footer.js
+++ b/marx_search_frontend/src/Footer.js
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+
+export default function Footer() {
+  const [image, setImage] = useState(null);
+
+  const handleImageChange = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImage(reader.result);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  return (
+    <footer className="bg-[#fceedd] dark:bg-[#1e1e1e] text-center py-6 text-gray-600 dark:text-gray-400 font-serif">
+      <div className="flex flex-col items-center space-y-3">
+        <span>© 2024 Marx Search</span>
+        <a href="#" className="text-blue-700 dark:text-blue-400 hover:underline">
+          Donate via PayPal
+        </a>
+        {image && <img src={image} alt="Footer" className="h-16" />}
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleImageChange}
+          className="text-gray-800 dark:text-gray-200"
+        />
+      </div>
+    </footer>
+  );
+}

--- a/marx_search_frontend/src/pages/WorksList.js
+++ b/marx_search_frontend/src/pages/WorksList.js
@@ -6,27 +6,29 @@ export default function WorksList() {
   const { works, setCurrentWorkId } = useContext(WorkContext);
 
   return (
-    <div className="p-6 bg-[#fceedd] dark:bg-[#1e1e1e] min-h-screen text-gray-800 dark:text-gray-200 font-serif">
-      <h1 className="text-3xl font-bold mb-8">Available Texts</h1>
-      <ul className="space-y-6">
-        {works.map((work) => (
-          <li key={work.id}>
-            <Link
-              to={`/works/${work.id}`}
-              onClick={() => setCurrentWorkId(work.id)}
-              className="text-xl text-blue-700 dark:text-blue-400 hover:underline font-medium"
-            >
-              {work.title}
-            </Link>
-            {work.author && (
-              <span className="ml-2 text-gray-600 dark:text-gray-400">{work.author}</span>
-            )}
-            {work.description && (
-              <p className="ml-4 text-gray-700 dark:text-gray-300 text-sm">{work.description}</p>
-            )}
-          </li>
-        ))}
-      </ul>
+    <div className="bg-gray-50 dark:bg-gray-900 min-h-screen py-10 px-4 text-gray-800 dark:text-gray-200 font-serif">
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-4xl font-semibold mb-10 text-center">Available Texts</h1>
+        <ul className="space-y-6">
+          {works.map((work) => (
+            <li key={work.id} className="bg-white dark:bg-gray-800 shadow rounded-md p-4">
+              <Link
+                to={`/works/${work.id}`}
+                onClick={() => setCurrentWorkId(work.id)}
+                className="text-2xl text-blue-700 dark:text-blue-400 hover:underline font-medium"
+              >
+                {work.title}
+              </Link>
+              {work.author && (
+                <span className="ml-2 text-gray-600 dark:text-gray-400">{work.author}</span>
+              )}
+              {work.description && (
+                <p className="mt-2 text-gray-700 dark:text-gray-300 text-sm">{work.description}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style the WorksList page with card layout and more neutral colors
- add a new Footer component with PayPal donation link and optional image upload
- include footer and layout wrapper in the main App

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848f0359ea0832cbc85b5c1c54a4fcf